### PR TITLE
There was a bug when creating a new post and selecting the format

### DIFF
--- a/src/components/forms/NewPostForm.jsx
+++ b/src/components/forms/NewPostForm.jsx
@@ -66,8 +66,8 @@ export const NewPostForm = ({ currentUser }) => {
       const newPostObject = {
         userId: currentUser.id,
         title: post.title,
-        formatId: post.formatId,
-        deckId: post.deckId,
+        formatId: parseInt(post.formatId),
+        deckId: parseInt(post.deckId),
         gameOver: false,
         body: post.body,
         date: new Date().toLocaleString(),


### PR DESCRIPTION
### Purpose
To fix a bug for when selecting a format when you create a post. the FormatId was not being assigned correctly

### Files Changed
- update how the formatId and the deckId were being assigned in `NewPostForm.jsx`


### Testing
Fetch, host the `Capstone-api`JSON server, Run "npm run dev"
- Check that when you create a new post and navigate to the AllPosts page. filter the page to the format you chose when you created the post. You should see the correct posts for the chosen format